### PR TITLE
Refresh token için Redis tabanlı rotation ve logout desteği eklendi

### DIFF
--- a/src/main/java/com/babyvo/babyvo/controller/auth/AuthEmailController.java
+++ b/src/main/java/com/babyvo/babyvo/controller/auth/AuthEmailController.java
@@ -8,6 +8,8 @@ import com.babyvo.babyvo.response.auth.AuthTokensResponse;
 import com.babyvo.babyvo.response.auth.StartEmailOtpResponse;
 import com.babyvo.babyvo.service.auth.EmailAuthService;
 import com.babyvo.babyvo.service.auth.EmailOtpService;
+import com.babyvo.babyvo.service.auth.RefreshTokenStore;
+import com.babyvo.babyvo.service.auth.jwt.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +24,14 @@ public class AuthEmailController {
 
     private final EmailOtpService emailOtpService;
     private final EmailAuthService emailAuthService;
+    private final JwtService jwtService;
+    private final RefreshTokenStore refreshTokenStore;
 
     @PostMapping("/start")
     public ApiResult<StartEmailOtpResponse> start(@Valid @RequestBody StartEmailOtpRequest req,
-                                       HttpServletRequest httpReq) {
+                                                  HttpServletRequest httpReq) {
         String ip = httpReq.getRemoteAddr();
-        String userAgent = httpReq.getHeader("UserEntity-Agent");
+        String userAgent = httpReq.getHeader("User-Agent"); // ✅ doğru header
 
         UUID otpRef = emailOtpService.start(req.email(), ip, userAgent);
         return ApiResult.ok(new StartEmailOtpResponse(otpRef.toString(), 180));
@@ -37,21 +41,29 @@ public class AuthEmailController {
     public ApiResult<AuthTokensResponse> verify(@Valid @RequestBody VerifyEmailOtpRequest req) {
         UUID otpRef = UUID.fromString(req.otpRef());
 
-        // OTP doğrula (consumed eder)
+        // 1) OTP doğrula (consumed eder)
         emailOtpService.verifyOrThrow(otpRef, req.otp());
 
-        // OTP kaydından email'i çekmek için
+        // 2) OTP kaydından email'i çek
         String email = emailOtpService.getEmailByOtpRef(otpRef);
 
+        // 3) User bul/oluştur
         UserEntity user = emailAuthService.findOrCreateEmailUser(email);
 
-        String access = emailAuthService.accessToken(user);
-        String refresh = emailAuthService.refreshToken(user);
+        // 4) JWT üret (access + refresh rotation)
+        String access = jwtService.createAccessToken(user.getId());
+
+        JwtService.IssuedRefreshToken issuedRefresh = jwtService.issueRefreshToken(user.getId());
+        refreshTokenStore.storeActive(
+                issuedRefresh.jti(),
+                user.getId(),
+                issuedRefresh.ttlFromNow()
+        );
 
         return ApiResult.ok(new AuthTokensResponse(
                 access,
-                refresh,
-                new AuthTokensResponse.UserInfo(user.getId(), user.getPrimaryEmail()))
-        );
+                issuedRefresh.token(),
+                new AuthTokensResponse.UserInfo(user.getId(), user.getPrimaryEmail())
+        ));
     }
 }

--- a/src/main/java/com/babyvo/babyvo/controller/auth/AuthLogoutController.java
+++ b/src/main/java/com/babyvo/babyvo/controller/auth/AuthLogoutController.java
@@ -1,0 +1,22 @@
+package com.babyvo.babyvo.controller.auth;
+
+import com.babyvo.babyvo.common.apis.ApiResult;
+import com.babyvo.babyvo.request.auth.LogoutRequest;
+import com.babyvo.babyvo.service.auth.AuthTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthLogoutController {
+
+    private final AuthTokenService authTokenService;
+
+    @PostMapping("/logout")
+    public ApiResult<Void> logout(@RequestBody @Valid LogoutRequest req) {
+        authTokenService.logout(req.refreshToken());
+        return ApiResult.ok(null);
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/controller/auth/AuthTokenController.java
+++ b/src/main/java/com/babyvo/babyvo/controller/auth/AuthTokenController.java
@@ -1,0 +1,22 @@
+package com.babyvo.babyvo.controller.auth;
+
+import com.babyvo.babyvo.common.apis.ApiResult;
+import com.babyvo.babyvo.request.auth.RefreshTokenRequest;
+import com.babyvo.babyvo.response.auth.AuthTokensResponse;
+import com.babyvo.babyvo.service.auth.AuthTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/token")
+public class AuthTokenController {
+
+    private final AuthTokenService authTokenService;
+
+    @PostMapping("/refresh")
+    public ApiResult<AuthTokensResponse> refresh(@RequestBody @Valid RefreshTokenRequest request) {
+        return ApiResult.ok(authTokenService.refresh(request.refreshToken()));
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/request/auth/LogoutRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/auth/LogoutRequest.java
@@ -1,0 +1,7 @@
+package com.babyvo.babyvo.request.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+        @NotBlank String refreshToken
+) {}

--- a/src/main/java/com/babyvo/babyvo/request/auth/RefreshTokenRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/auth/RefreshTokenRequest.java
@@ -1,0 +1,7 @@
+package com.babyvo.babyvo.request.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank String refreshToken
+) {}

--- a/src/main/java/com/babyvo/babyvo/service/auth/AuthTokenService.java
+++ b/src/main/java/com/babyvo/babyvo/service/auth/AuthTokenService.java
@@ -1,0 +1,110 @@
+package com.babyvo.babyvo.service.auth;
+
+import com.babyvo.babyvo.common.exception.BusinessException;
+import com.babyvo.babyvo.entity.user.UserEntity;
+import com.babyvo.babyvo.repository.user.UserRepository;
+import com.babyvo.babyvo.response.auth.AuthTokensResponse;
+import com.babyvo.babyvo.service.auth.jwt.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthTokenService {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private final RefreshTokenStore refreshTokenStore;
+
+    @Transactional(readOnly = true)
+    public AuthTokensResponse refresh(String refreshToken) {
+        JwtService.ParsedRefreshToken parsed;
+        try {
+            parsed = jwtService.parseRefreshToken(refreshToken);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_INVALID");
+        }
+
+        UUID userId = parsed.userId();
+        String jti = parsed.jti();
+
+        // Token'ın kalan TTL'ini güvenli hesapla (negatif olmasın)
+        Duration ttl = safeTtl(parsed.expiresAt());
+        if (ttl.isZero()) {
+            // JWT parse geçmiş olsa bile exp çok yakın/ geçmiş olabilir
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_EXPIRED");
+        }
+
+        // 1) Redis'te aktif mi?
+        if (!refreshTokenStore.isActiveForUser(jti, userId)) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_REVOKED_OR_EXPIRED");
+        }
+
+        // 2) Reuse (tekrar kullanım) koruması: atomic
+        boolean firstUse = refreshTokenStore.markUsedOnce(jti, ttl);
+        if (!firstUse) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_REUSED");
+        }
+
+        // 3) Eski refresh'i iptal et (rotation)
+        refreshTokenStore.revoke(jti);
+
+        // 4) User halen geçerli mi?
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        if (Boolean.TRUE.equals(user.getIsDeleted())) {
+            throw new BusinessException(HttpStatus.UNAUTHORIZED, "USER_DELETED");
+        }
+
+        // 5) Yeni tokenlar
+        String newAccess = jwtService.createAccessToken(userId);
+
+        JwtService.IssuedRefreshToken newRefresh = jwtService.issueRefreshToken(userId);
+        refreshTokenStore.storeActive(newRefresh.jti(), userId, newRefresh.ttlFromNow());
+
+        var userInfo = new AuthTokensResponse.UserInfo(user.getId(), user.getPrimaryEmail());
+        return new AuthTokensResponse(newAccess, newRefresh.token(), userInfo);
+    }
+
+    private static Duration safeTtl(Instant expiresAt) {
+        Instant now = Instant.now();
+        if (expiresAt == null || expiresAt.isBefore(now)) return Duration.ZERO;
+
+        Duration d = Duration.between(now, expiresAt);
+
+        // “0” olmasın diye min 1 saniye clamp (Redis TTL 0 bazen sorun çıkarır)
+        if (d.isZero() || d.isNegative()) return Duration.ZERO;
+
+        return d;
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+        // Logout idempotent olmalı:
+        // token invalid/revoked olsa bile 200 döneceğiz (probe engeller)
+        JwtService.ParsedRefreshToken parsed;
+        try {
+            parsed = jwtService.parseRefreshToken(refreshToken);
+        } catch (Exception ignored) {
+            return;
+        }
+
+        UUID userId = parsed.userId();
+        String jti = parsed.jti();
+
+        // sadece bu user’a ait aktif token ise revoke et
+        if (refreshTokenStore.isActiveForUser(jti, userId)) {
+            refreshTokenStore.revoke(jti);
+        }
+
+        // (Opsiyonel) reuse denemelerini daha hızlı kesmek istersen:
+        // refreshTokenStore.markUsedOnce(jti, safeTtl(parsed.expiresAt()));
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/auth/EmailAuthService.java
+++ b/src/main/java/com/babyvo/babyvo/service/auth/EmailAuthService.java
@@ -43,7 +43,7 @@ public class EmailAuthService {
         return jwtService.createAccessToken(user.getId());
     }
 
-    public String refreshToken(UserEntity user) {
-        return jwtService.createRefreshToken(user.getId());
+    public JwtService.IssuedRefreshToken issueRefreshToken(UserEntity user) {
+        return jwtService.issueRefreshToken(user.getId());
     }
 }

--- a/src/main/java/com/babyvo/babyvo/service/auth/RefreshTokenStore.java
+++ b/src/main/java/com/babyvo/babyvo/service/auth/RefreshTokenStore.java
@@ -1,0 +1,43 @@
+package com.babyvo.babyvo.service.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenStore {
+
+    private final StringRedisTemplate redis;
+
+    private static final String ACTIVE_PREFIX = "babyvo:rt:active:";
+    private static final String USED_PREFIX  = "babyvo:rt:used:";
+
+    private String activeKey(String jti) { return ACTIVE_PREFIX + jti; }
+    private String usedKey(String jti) { return USED_PREFIX + jti; }
+
+    /** Login/refresh sonrası yeni refresh token'ı aktif olarak kaydet */
+    public void storeActive(String jti, UUID userId, Duration ttl) {
+        redis.opsForValue().set(activeKey(jti), userId.toString(), ttl);
+    }
+
+    /** Token aktif mi + user match mi */
+    public boolean isActiveForUser(String jti, UUID userId) {
+        String val = redis.opsForValue().get(activeKey(jti));
+        return userId.toString().equals(val);
+    }
+
+    /** Atomic: ilk kez kullanılıyorsa true, tekrar kullanım ise false */
+    public boolean markUsedOnce(String jti, Duration ttl) {
+        Boolean ok = redis.opsForValue().setIfAbsent(usedKey(jti), "1", ttl);
+        return Boolean.TRUE.equals(ok);
+    }
+
+    /** Eski refresh token'ı iptal et */
+    public void revoke(String jti) {
+        redis.delete(activeKey(jti));
+    }
+}


### PR DESCRIPTION
- Refresh token’lar Redis üzerinde active/used olarak yönetildi
- Refresh token rotation ve reuse (replay) koruması sağlandı
- Auth token refresh akışı production seviyesine çıkarıldı
- Logout endpoint eklendi (refresh token revoke)
- Email ve Google login akışları yeni JWT/refresh modeliyle uyumlu hale getirildi
- JwtService refresh token üretimi jti ve expiration bilgisi ile revize edildi