### PR TITLE
BabyVo uygulamasının temel domain’i olan

### DIFF
--- a/src/main/java/com/babyvo/babyvo/controller/baby/BabyController.java
+++ b/src/main/java/com/babyvo/babyvo/controller/baby/BabyController.java
@@ -1,0 +1,46 @@
+package com.babyvo.babyvo.controller.baby;
+
+import com.babyvo.babyvo.common.apis.ApiResult;
+import com.babyvo.babyvo.request.baby.CreateBabyRequest;
+import com.babyvo.babyvo.request.baby.UpdateBabyRequest;
+import com.babyvo.babyvo.response.baby.BabyResponse;
+import com.babyvo.babyvo.service.baby.BabyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/babies")
+@RequiredArgsConstructor
+public class BabyController {
+
+    private final BabyService babyService;
+
+    @PostMapping
+    public ApiResult<BabyResponse> create(@Valid @RequestBody CreateBabyRequest req, Authentication auth) {
+        UUID userId = (UUID) auth.getPrincipal();
+        return ApiResult.ok(babyService.create(req, userId));
+    }
+
+    @GetMapping
+    public ApiResult<List<BabyResponse>> list(Authentication auth) {
+        UUID userId = (UUID) auth.getPrincipal();
+        return ApiResult.ok(babyService.listMine(userId));
+    }
+
+    @GetMapping("/{babyId}")
+    public ApiResult<BabyResponse> getById(@PathVariable UUID babyId, Authentication auth) {
+        UUID userId = (UUID) auth.getPrincipal();
+        return ApiResult.ok(babyService.getMineById(babyId, userId));
+    }
+
+    @PatchMapping("/{babyId}")
+    public ApiResult<BabyResponse> update(@PathVariable UUID babyId, @Valid @RequestBody UpdateBabyRequest req, Authentication auth) {
+        UUID userId = (UUID) auth.getPrincipal();
+        return ApiResult.ok(babyService.update(babyId, req, userId));
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/controller/invite/BabyInviteController.java
+++ b/src/main/java/com/babyvo/babyvo/controller/invite/BabyInviteController.java
@@ -1,0 +1,51 @@
+package com.babyvo.babyvo.controller.invite;
+
+import com.babyvo.babyvo.common.apis.ApiResult;
+import com.babyvo.babyvo.request.invite.AcceptInviteRequest;
+import com.babyvo.babyvo.request.invite.CreateInviteRequest;
+import com.babyvo.babyvo.request.invite.RejectInviteRequest;
+import com.babyvo.babyvo.response.invite.AcceptInviteResponse;
+import com.babyvo.babyvo.response.invite.CreateInviteResponse;
+import com.babyvo.babyvo.service.invite.BabyInviteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class BabyInviteController {
+
+    private final BabyInviteService babyInviteService;
+
+    @PostMapping("/api/v1/babies/{babyId}/invites")
+    public ApiResult<CreateInviteResponse> createInvite(
+            @PathVariable UUID babyId,
+            @Valid @RequestBody CreateInviteRequest req,
+            Authentication auth
+    ) {
+        UUID currentUserId = UUID.fromString(auth.getName());
+        return ApiResult.ok(babyInviteService.create(babyId, currentUserId, req));
+    }
+
+    @PostMapping("/api/v1/invites/accept")
+    public ApiResult<AcceptInviteResponse> accept(
+            @Valid @RequestBody AcceptInviteRequest req,
+            Authentication auth
+    ) {
+        UUID currentUserId = UUID.fromString(auth.getName());
+        return ApiResult.ok(babyInviteService.accept(req.inviteToken(), currentUserId));
+    }
+
+    @PostMapping("/api/v1/invites/reject")
+    public ApiResult<Void> reject(
+            @Valid @RequestBody RejectInviteRequest req,
+            Authentication auth
+    ) {
+        UUID currentUserId = UUID.fromString(auth.getName());
+        babyInviteService.reject(req.inviteToken(), currentUserId);
+        return ApiResult.ok(null);
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/entity/enums/InviteStatus.java
+++ b/src/main/java/com/babyvo/babyvo/entity/enums/InviteStatus.java
@@ -4,5 +4,6 @@ public enum InviteStatus {
     PENDING,
     ACCEPTED,
     CANCELLED,
-    EXPIRED
+    EXPIRED,
+    REJECTED
 }

--- a/src/main/java/com/babyvo/babyvo/entity/invite/BabyInviteEntity.java
+++ b/src/main/java/com/babyvo/babyvo/entity/invite/BabyInviteEntity.java
@@ -17,10 +17,13 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         name = "baby_invites",
+        uniqueConstraints = {
+                @UniqueConstraint(name="uk_invite_token_hash", columnNames={"token_hash"})
+        },
         indexes = {
                 @Index(name = "idx_invites_baby_status", columnList = "baby_id,status"),
                 @Index(name = "idx_invites_email_status", columnList = "invited_email,status"),
-                @Index(name = "idx_invites_expires_at", columnList = "expiresAt")
+                @Index(name = "idx_invites_expires_at", columnList = "expires_at")
         }
 )
 @Getter

--- a/src/main/java/com/babyvo/babyvo/repository/baby/BabyParentRepository.java
+++ b/src/main/java/com/babyvo/babyvo/repository/baby/BabyParentRepository.java
@@ -1,0 +1,15 @@
+package com.babyvo.babyvo.repository.baby;
+
+import com.babyvo.babyvo.entity.baby.BabyParentEntity;
+import com.babyvo.babyvo.entity.enums.BabyParentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BabyParentRepository extends JpaRepository<BabyParentEntity, Long> {
+    Optional<BabyParentEntity> findByBabyEntity_IdAndUserEntity_Id(UUID babyId, UUID userId);
+    List<BabyParentEntity> findAllByUserEntity_IdAndStatus(UUID userId, BabyParentStatus status);
+    boolean existsByBabyEntity_IdAndUserEntity_IdAndStatus(UUID babyId, UUID userId, BabyParentStatus status);
+}

--- a/src/main/java/com/babyvo/babyvo/repository/baby/BabyRepository.java
+++ b/src/main/java/com/babyvo/babyvo/repository/baby/BabyRepository.java
@@ -1,0 +1,9 @@
+package com.babyvo.babyvo.repository.baby;
+
+import com.babyvo.babyvo.entity.baby.BabyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface BabyRepository extends JpaRepository<BabyEntity, UUID> {
+}

--- a/src/main/java/com/babyvo/babyvo/repository/invite/BabyInviteRepository.java
+++ b/src/main/java/com/babyvo/babyvo/repository/invite/BabyInviteRepository.java
@@ -1,0 +1,11 @@
+package com.babyvo.babyvo.repository.invite;
+
+import com.babyvo.babyvo.entity.invite.BabyInviteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BabyInviteRepository extends JpaRepository<BabyInviteEntity, UUID> {
+    Optional<BabyInviteEntity> findByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/babyvo/babyvo/request/baby/CreateBabyRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/baby/CreateBabyRequest.java
@@ -1,0 +1,13 @@
+package com.babyvo.babyvo.request.baby;
+
+import com.babyvo.babyvo.entity.enums.BabySex;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record CreateBabyRequest(
+        @NotBlank String name,
+        @NotNull LocalDate birthDate,
+        @NotNull BabySex sex
+) {}

--- a/src/main/java/com/babyvo/babyvo/request/baby/UpdateBabyRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/baby/UpdateBabyRequest.java
@@ -1,0 +1,14 @@
+package com.babyvo.babyvo.request.baby;
+
+import com.babyvo.babyvo.entity.enums.BabySex;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public record UpdateBabyRequest(
+        Optional<String> name,
+        Optional<LocalDate> birthDate,
+        Optional<BabySex> sex
+) {}

--- a/src/main/java/com/babyvo/babyvo/request/invite/AcceptInviteRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/invite/AcceptInviteRequest.java
@@ -1,0 +1,7 @@
+package com.babyvo.babyvo.request.invite;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AcceptInviteRequest(
+        @NotBlank String inviteToken
+) {}

--- a/src/main/java/com/babyvo/babyvo/request/invite/CreateInviteRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/invite/CreateInviteRequest.java
@@ -1,0 +1,5 @@
+package com.babyvo.babyvo.request.invite;
+
+import com.babyvo.babyvo.entity.enums.BabyPermission;
+
+public record CreateInviteRequest(String email, BabyPermission permission) {}

--- a/src/main/java/com/babyvo/babyvo/request/invite/RejectInviteRequest.java
+++ b/src/main/java/com/babyvo/babyvo/request/invite/RejectInviteRequest.java
@@ -1,0 +1,7 @@
+package com.babyvo.babyvo.request.invite;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RejectInviteRequest(
+        @NotBlank String inviteToken
+) {}

--- a/src/main/java/com/babyvo/babyvo/response/baby/BabyResponse.java
+++ b/src/main/java/com/babyvo/babyvo/response/baby/BabyResponse.java
@@ -1,0 +1,13 @@
+package com.babyvo.babyvo.response.baby;
+
+import com.babyvo.babyvo.entity.enums.BabySex;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record BabyResponse(
+        UUID id,
+        String name,
+        LocalDate birthDate,
+        BabySex sex
+) {}

--- a/src/main/java/com/babyvo/babyvo/response/invite/AcceptInviteResponse.java
+++ b/src/main/java/com/babyvo/babyvo/response/invite/AcceptInviteResponse.java
@@ -1,0 +1,10 @@
+package com.babyvo.babyvo.response.invite;
+
+import com.babyvo.babyvo.entity.enums.BabyParentStatus;
+
+import java.util.UUID;
+
+public record AcceptInviteResponse(
+        UUID babyId,
+        BabyParentStatus status
+) {}

--- a/src/main/java/com/babyvo/babyvo/response/invite/CreateInviteResponse.java
+++ b/src/main/java/com/babyvo/babyvo/response/invite/CreateInviteResponse.java
@@ -1,0 +1,7 @@
+package com.babyvo.babyvo.response.invite;
+
+public record CreateInviteResponse(
+        String inviteToken,
+        long expiresInHours,
+        boolean emailSent
+) {}

--- a/src/main/java/com/babyvo/babyvo/service/auth/AppleTokenVerifier.java
+++ b/src/main/java/com/babyvo/babyvo/service/auth/AppleTokenVerifier.java
@@ -30,7 +30,7 @@ public class AppleTokenVerifier {
 
     private final RestClient restClient = RestClient.create();
 
-    public AppleTokenVerifier(@Value("${babyvo.apple.client-id}") String clientId) {
+    public AppleTokenVerifier(@Value("${babyvo.auth.apple.client-id}") String clientId) {
         this.clientId = clientId;
     }
 

--- a/src/main/java/com/babyvo/babyvo/service/baby/BabyAccessService.java
+++ b/src/main/java/com/babyvo/babyvo/service/baby/BabyAccessService.java
@@ -1,0 +1,24 @@
+package com.babyvo.babyvo.service.security;
+
+import com.babyvo.babyvo.common.exception.BusinessException;
+import com.babyvo.babyvo.entity.enums.BabyParentStatus;
+import com.babyvo.babyvo.repository.baby.BabyParentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BabyAccessService {
+
+    private final BabyParentRepository babyParentRepository;
+
+    public void requireActiveParent(UUID babyId, UUID userId) {
+        boolean ok = babyParentRepository.existsByBabyEntity_IdAndUserEntity_IdAndStatus(babyId, userId, BabyParentStatus.ACTIVE);
+        if (!ok) {
+            throw new BusinessException(HttpStatus.FORBIDDEN, "BABY_ACCESS_DENIED");
+        }
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/baby/BabyService.java
+++ b/src/main/java/com/babyvo/babyvo/service/baby/BabyService.java
@@ -1,0 +1,116 @@
+package com.babyvo.babyvo.service.baby;
+
+import com.babyvo.babyvo.common.exception.BusinessException;
+import com.babyvo.babyvo.entity.baby.BabyEntity;
+import com.babyvo.babyvo.entity.baby.BabyParentEntity;
+import com.babyvo.babyvo.entity.enums.BabyParentRole;
+import com.babyvo.babyvo.entity.enums.BabyParentStatus;
+import com.babyvo.babyvo.entity.user.UserEntity;
+import com.babyvo.babyvo.repository.baby.BabyParentRepository;
+import com.babyvo.babyvo.repository.baby.BabyRepository;
+import com.babyvo.babyvo.repository.user.UserRepository;
+import com.babyvo.babyvo.request.baby.CreateBabyRequest;
+import com.babyvo.babyvo.request.baby.UpdateBabyRequest;
+import com.babyvo.babyvo.response.baby.BabyResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BabyService {
+
+    private final BabyRepository babyRepository;
+    private final BabyParentRepository babyParentRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public BabyResponse create(CreateBabyRequest req, UUID currentUserId) {
+        UserEntity user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        BabyEntity baby = new BabyEntity();
+        baby.setName(req.name());
+        baby.setBirthDate(req.birthDate());
+        baby.setSex(req.sex());
+        baby.setCreatedByUserEntity(user);
+        baby.setCreatedAt(LocalDateTime.now());
+        baby.setCreatedBy(user.getPrimaryEmail());
+
+        baby = babyRepository.save(baby);
+
+        BabyParentEntity rel = new BabyParentEntity();
+        rel.setBabyEntity(baby);
+        rel.setUserEntity(user);
+        rel.setRole(BabyParentRole.OWNER);
+        rel.setStatus(BabyParentStatus.ACTIVE);
+
+        babyParentRepository.save(rel);
+
+        return new BabyResponse(baby.getId(), baby.getName(), baby.getBirthDate(), baby.getSex());
+    }
+
+    @Transactional(readOnly = true)
+    public List<BabyResponse> listMine(UUID currentUserId) {
+        // User -> active parents -> baby list
+        return babyParentRepository.findAllByUserEntity_IdAndStatus(currentUserId, BabyParentStatus.ACTIVE)
+                .stream()
+                .map(bp -> {
+                    BabyEntity b = bp.getBabyEntity();
+                    return new BabyResponse(b.getId(), b.getName(), b.getBirthDate(), b.getSex());
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public BabyResponse getMineById(UUID babyId, UUID currentUserId) {
+
+        // Kullanıcı var mı? (sen create'de kontrol ediyorsun, burada da tutarlı olsun)
+        userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        // Bu kullanıcı bu bebeğe ACTIVE parent mı?
+        boolean hasAccess = babyParentRepository
+                .existsByBabyEntity_IdAndUserEntity_IdAndStatus(babyId, currentUserId, BabyParentStatus.ACTIVE);
+
+        if (!hasAccess) {
+            throw new BusinessException(HttpStatus.FORBIDDEN, "BABY_ACCESS_DENIED");
+        }
+
+        BabyEntity baby = babyRepository.findById(babyId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "BABY_NOT_FOUND"));
+
+        return new BabyResponse(baby.getId(), baby.getName(), baby.getBirthDate(), baby.getSex());
+    }
+
+    public BabyResponse update(UUID babyId, @Valid UpdateBabyRequest req, UUID currentUserId) {
+        UserEntity user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        // Bu kullanıcı bu bebeğe ACTIVE parent mı?
+        boolean hasAccess = babyParentRepository
+                .existsByBabyEntity_IdAndUserEntity_IdAndStatus(babyId, currentUserId, BabyParentStatus.ACTIVE);
+
+        if (!hasAccess) {
+            throw new BusinessException(HttpStatus.FORBIDDEN, "BABY_ACCESS_DENIED");
+        }
+
+        BabyEntity baby = babyRepository.findById(babyId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "BABY_NOT_FOUND"));
+
+        req.name().ifPresent(baby::setName);
+        req.birthDate().ifPresent(baby::setBirthDate);
+        req.sex().ifPresent(baby::setSex);
+
+        babyRepository.save(baby);
+
+        return new BabyResponse(baby.getId(), baby.getName(), baby.getBirthDate(), baby.getSex());
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/invite/BabyInviteService.java
+++ b/src/main/java/com/babyvo/babyvo/service/invite/BabyInviteService.java
@@ -1,0 +1,168 @@
+package com.babyvo.babyvo.service.invite;
+
+import com.babyvo.babyvo.common.exception.BusinessException;
+import com.babyvo.babyvo.entity.baby.BabyEntity;
+import com.babyvo.babyvo.entity.baby.BabyParentEntity;
+import com.babyvo.babyvo.entity.enums.BabyParentRole;
+import com.babyvo.babyvo.entity.enums.BabyParentStatus;
+import com.babyvo.babyvo.entity.invite.BabyInviteEntity;
+import com.babyvo.babyvo.entity.enums.InviteStatus;
+import com.babyvo.babyvo.entity.user.UserEntity;
+import com.babyvo.babyvo.repository.baby.BabyParentRepository;
+import com.babyvo.babyvo.repository.baby.BabyRepository;
+import com.babyvo.babyvo.repository.invite.BabyInviteRepository;
+import com.babyvo.babyvo.repository.user.UserRepository;
+import com.babyvo.babyvo.request.invite.CreateInviteRequest;
+import com.babyvo.babyvo.response.invite.AcceptInviteResponse;
+import com.babyvo.babyvo.response.invite.CreateInviteResponse;
+import com.babyvo.babyvo.service.mail.EmailSender;
+import com.babyvo.babyvo.service.security.BabyAccessService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BabyInviteService {
+
+
+    private final BabyRepository babyRepository;
+    private final BabyInviteRepository babyInviteRepository;
+    private final UserRepository userRepository;
+    private final BabyParentRepository babyParentRepository;
+    private final BabyAccessService babyAccessService;
+
+    private final InviteTokenGenerator inviteTokenGenerator;
+    private final InviteTokenHasher inviteTokenHasher;
+
+    private final EmailSender emailSender;
+
+    private static final long DEFAULT_EXPIRE_HOURS = 168; // 7 gün
+
+    @Transactional
+    public CreateInviteResponse create(UUID babyId, UUID currentUserId, CreateInviteRequest req) {
+        babyAccessService.requireActiveParent(babyId, currentUserId);
+
+        BabyEntity baby = babyRepository.findById(babyId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "BABY_NOT_FOUND"));
+
+        UserEntity inviter = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        String token = inviteTokenGenerator.generate();       // plain
+        String tokenHash = inviteTokenHasher.hash(token);     // db
+
+        BabyInviteEntity invite = new BabyInviteEntity();
+        invite.setBabyEntity(baby);
+        invite.setInvitedEmail(req.email()); // nullable
+        invite.setTokenHash(tokenHash);
+        invite.setExpiresAt(LocalDateTime.now().plusHours(DEFAULT_EXPIRE_HOURS));
+        invite.setStatus(InviteStatus.PENDING);
+        invite.setPermission(req.permission());
+        invite.setCreatedByUserEntity(inviter);
+
+        try {
+            babyInviteRepository.save(invite);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(HttpStatus.CONFLICT, "INVITE_TOKEN_CONFLICT");
+        }
+
+        boolean emailSent = false;
+
+        if (req.email() != null && !req.email().isBlank()) {
+            emailSender.sendInvite(
+                    req.email(),
+                    baby.getName(),
+                    token,
+                    DEFAULT_EXPIRE_HOURS
+            );
+            emailSent = true;
+        }
+
+        return new CreateInviteResponse(token, DEFAULT_EXPIRE_HOURS, emailSent);
+    }
+
+    @Transactional
+    public AcceptInviteResponse accept(String token, UUID currentUserId) {
+        String tokenHash = inviteTokenHasher.hash(token);
+
+        BabyInviteEntity invite = babyInviteRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "INVITE_NOT_FOUND"));
+
+        if (invite.getStatus() != InviteStatus.PENDING) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "INVITE_NOT_PENDING");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (invite.isExpired(now)) {
+            invite.setStatus(InviteStatus.EXPIRED);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "INVITE_EXPIRED");
+        }
+
+        UserEntity user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        if (invite.getInvitedEmail() != null) {
+            String userEmail = user.getPrimaryEmail();
+            if (userEmail == null || !userEmail.equalsIgnoreCase(invite.getInvitedEmail())) {
+                throw new BusinessException(HttpStatus.FORBIDDEN, "INVITE_EMAIL_MISMATCH");
+            }
+        }
+
+        UUID babyId = invite.getBabyEntity().getId();
+
+        boolean alreadyActive = babyParentRepository
+                .existsByBabyEntity_IdAndUserEntity_IdAndStatus(babyId, currentUserId, BabyParentStatus.ACTIVE);
+
+        if (!alreadyActive) {
+            BabyParentEntity rel = new BabyParentEntity();
+            rel.setBabyEntity(invite.getBabyEntity());
+            rel.setUserEntity(user);
+            rel.setStatus(BabyParentStatus.ACTIVE);
+            rel.setPermission(invite.getPermission());
+            rel.setRole(BabyParentRole.PARENT);
+            babyParentRepository.save(rel);
+        }
+
+        invite.setStatus(InviteStatus.ACCEPTED);
+        invite.setAcceptedByUserEntity(user);
+        invite.setAcceptedAt(now);
+
+        return new AcceptInviteResponse(babyId, BabyParentStatus.ACTIVE);
+    }
+
+    @Transactional
+    public void reject(String token, UUID currentUserId) {
+        String tokenHash = inviteTokenHasher.hash(token);
+
+        BabyInviteEntity invite = babyInviteRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new BusinessException(HttpStatus.NOT_FOUND, "INVITE_NOT_FOUND"));
+
+        if (invite.getStatus() != InviteStatus.PENDING) {
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "INVITE_NOT_PENDING");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (invite.isExpired(now)) {
+            invite.setStatus(InviteStatus.EXPIRED);
+            throw new BusinessException(HttpStatus.BAD_REQUEST, "INVITE_EXPIRED");
+        }
+
+        UserEntity user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new BusinessException(HttpStatus.UNAUTHORIZED, "USER_NOT_FOUND"));
+
+        if (invite.getInvitedEmail() != null) {
+            String userEmail = user.getPrimaryEmail();
+            if (userEmail == null || !userEmail.equalsIgnoreCase(invite.getInvitedEmail())) {
+                throw new BusinessException(HttpStatus.FORBIDDEN, "INVITE_EMAIL_MISMATCH");
+            }
+        }
+
+        invite.setStatus(InviteStatus.REJECTED);
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/invite/InviteTokenGenerator.java
+++ b/src/main/java/com/babyvo/babyvo/service/invite/InviteTokenGenerator.java
@@ -1,0 +1,18 @@
+package com.babyvo.babyvo.service.invite;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class InviteTokenGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public String generate() {
+        byte[] bytes = new byte[32]; // 256-bit
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/invite/InviteTokenHasher.java
+++ b/src/main/java/com/babyvo/babyvo/service/invite/InviteTokenHasher.java
@@ -1,0 +1,34 @@
+package com.babyvo.babyvo.service.invite;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class InviteTokenHasher {
+
+    private static final String HMAC_ALGO = "HmacSHA256";
+
+    private final byte[] secret;
+
+    public InviteTokenHasher(
+            @Value("${babyvo.invite.secret}") String secret
+    ) {
+        this.secret = secret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String hash(String token) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGO);
+            mac.init(new SecretKeySpec(secret, HMAC_ALGO));
+            byte[] raw = mac.doFinal(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(raw);
+        } catch (Exception e) {
+            throw new IllegalStateException("INVITE_TOKEN_HASH_FAILED", e);
+        }
+    }
+}

--- a/src/main/java/com/babyvo/babyvo/service/mail/EmailSender.java
+++ b/src/main/java/com/babyvo/babyvo/service/mail/EmailSender.java
@@ -2,4 +2,10 @@ package com.babyvo.babyvo.service.mail;
 
 public interface EmailSender {
     void sendOtp(String toEmail, String otp, int expiresMinutes);
+    void sendInvite(
+            String toEmail,
+            String babyName,
+            String inviteToken,
+            long expiresHours
+    );
 }

--- a/src/main/java/com/babyvo/babyvo/service/mail/SmtpEmailSender.java
+++ b/src/main/java/com/babyvo/babyvo/service/mail/SmtpEmailSender.java
@@ -29,4 +29,28 @@ public class SmtpEmailSender implements EmailSender {
 
         mailSender.send(msg);
     }
+
+    @Override
+    public void sendInvite(String toEmail,
+                           String babyName,
+                           String inviteToken,
+                           long expiresHours) {
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo(toEmail);
+        msg.setSubject("BabyVo - Baby Invite");
+        msg.setText("""
+                You have been invited to manage the baby "%s" on BabyVo.
+
+                Invite code:
+                %s
+
+                This invite expires in %d hours.
+
+                Open the app and accept the invite to continue.
+                """.formatted(babyName, inviteToken, expiresHours));
+
+        mailSender.send(msg);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,9 @@ babyvo:
     google:
       client-id: ${GOOGLE_CLIENT_ID}
     apple:
-      client-id: ${APPLE_CLIENT_ID}
+      client-id: ${APPLE_CLIENT_ID:com.yourcompany.babyvo}
+  invite:
+    secret: ${INVITE_SECRET}
 
 logging:
   level:


### PR DESCRIPTION
“bebek profili + ebeveyn paylaşımı” akışı uçtan uca tamamlandı.

 Baby tarafı:
- Bebek oluşturma (POST /api/v1/babies)
- Kullanıcının erişebildiği bebekleri listeleme
- Bebek detay görüntüleme
- Bebek bilgilerini güncelleme
- Oluşturan kullanıcının otomatik OWNER / ACTIVE parent olarak atanması

 Invite (ebeveyn ekleme) tarafı:
- Bebek için email veya token bazlı davet oluşturma
- Davet token’larının güvenli şekilde hash’lenerek DB’de tutulması
- Invite accept akışı:
  - Token doğrulama
  - Expire kontrolü
  - Email eşleşmesi (email invite için)
  - Parent ilişkisinin oluşturulması
  - Role & permission mapping
- Invite reject akışı
- Invite status yönetimi (PENDING / ACCEPTED / REJECTED / EXPIRED)

 Güvenlik & domain kuralları:
- Invite accept eden kullanıcıya varsayılan CO_PARENT rolü atanması
- Permission bilgisinin invite üzerinden taşınması
- OWNER rolünün yalnızca bebek oluşturan kullanıcıya verilmesi
- Token collision ve tekrar kullanım senaryolarının ele alınması

Email entegrasyonu:
- Invite ve OTP mail use-case’lerinin ayrıştırılması
- SMTP tabanlı email gönderim altyapısının genişletilmesi

Bu commit ile BabyVo’da
çoklu ebeveyn / paylaşımlı bebek yönetimi için gerekli minimum ama production’a yakın altyapı tamamlanmıştır.